### PR TITLE
Hiding double underscored from tool tip

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartTooltip.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip.jsx
@@ -6,6 +6,10 @@ import TooltipPopover from "metabase/components/TooltipPopover";
 import { getFriendlyName } from "metabase/visualizations/lib/utils";
 import { formatValue } from "metabase/lib/formatting";
 
+import {
+  isStartWithDoubleUnderscore
+} from "metabase/visualizations/lib/table";
+
 export default class ChartTooltip extends Component {
   static propTypes = {
     hovered: PropTypes.object,
@@ -19,7 +23,9 @@ export default class ChartTooltip extends Component {
     }
     if (Array.isArray(hovered.data)) {
       // Array of key, value, col: { data: [{ key, value, col }], element, event }
-      return hovered.data.map(d => ({
+      return hovered.data.filter(d => {
+        return !isStartWithDoubleUnderscore(d.col);
+      }).map(d => ({
         ...d,
         key: d.key || getFriendlyName(d.col),
       }));

--- a/frontend/src/metabase/visualizations/visualizations/PieChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart.jsx
@@ -380,7 +380,7 @@ export default class PieChart extends Component {
 
     const getSliceClickObject = index => {
       const slice = slices[index];
-      const sliceRows = slice.rowIndex != undefined && slice.rowIndex != null && rows[slice.rowIndex];
+      const sliceRows = slice.rowIndex !== undefined && slice.rowIndex !== null && rows[slice.rowIndex];
       const data =
         sliceRows &&
         sliceRows.map((value, index) => ({

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
   "edition": "enterprise",
-  "version" : "v0.38.1.36"
+  "version" : "v0.38.1.37"
 }


### PR DESCRIPTION
### What i have done

- eslint warning resolved `!=` > `!==` resolved.
- in the `ChartTooltip`, column name starts with double underscored are made hidden.
- version number increased.